### PR TITLE
fix: 随机模式下当前播放歌曲于列表中的位置出现错误和不同步的情况 (#2378)

### DIFF
--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -130,6 +130,8 @@ export default class {
     if (shuffle) {
       this._shuffleTheList();
     }
+    // 同步当前歌曲在列表中的下标
+    this.current = this.list.indexOf(this.currentTrackID);
   }
   get reversed() {
     return this._reversed;
@@ -892,7 +894,7 @@ export default class {
     if (autoPlayTrackID === 'first') {
       this._replaceCurrentTrack(this.list[0]);
     } else {
-      this.current = trackIDs.indexOf(autoPlayTrackID);
+      this.current = this.list.indexOf(autoPlayTrackID);
       this._replaceCurrentTrack(autoPlayTrackID);
     }
   }

--- a/src/views/next.vue
+++ b/src/views/next.vue
@@ -57,7 +57,9 @@ export default {
         this.player.current + 1,
         this.player.current + 100
       );
-      return this.tracks.filter(t => trackIDs.includes(t.id));
+      return trackIDs
+        .map(tid => this.tracks.find(t => t.id === tid))
+        .filter(t => t);
     },
     playNextList() {
       return this.player.playNextList;


### PR DESCRIPTION
* fix(Player.js): 随机模式下列表初始化时当前歌曲的下标异常

异常情况：假设歌曲A其在歌单中的位置为10，随机模式下双击该歌曲后，this.current != 10 原因：随机模式下，通过 indexOf 计算 current 时，调用的数组与真实的列表数组不一致

* fix(Player.js): 随机模式切换时未同步当前歌曲下标

* fix: 随机播放顺序与实际列表不一致

使用 filter 不保证返回的数组的元素顺序与传入的id 顺序对应